### PR TITLE
Add country restrictions for Finland

### DIFF
--- a/dist/countrylist.json
+++ b/dist/countrylist.json
@@ -346,7 +346,12 @@
         "abbreviation": "FI",
         "situation": {
             "state" : "NO",
-            "remark" : "No restrictions in place."
+            "travel": "Borders closed to non-essential travel. Starting 12am on 19 March",
+            "school" : "Schools are closed",
+            "event" : "Gatherings above 10 participants are restricted",
+            "health": "Visits to senior care and health facilities restricted",
+            "quarantaine" : "Over 70 year old residents required to stay in quarantine",
+            "shop": "All public sector recreational institutions are closed."
         }
     },
     {


### PR DESCRIPTION
As outlined in :
https://valtioneuvosto.fi/en/article/-/asset_publisher/10616/hallitus-totesi-suomen-olevan-poikkeusoloissa-koronavirustilanteen-vuoksi
https://www.gov.uk/foreign-travel-advice/finland

